### PR TITLE
Add `DateTime` data type to specification

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,3 +15,6 @@ markdown_extensions:
   - footnotes
 nav:
   - 'Introduction': introduction.md
+  - 'Data types':
+    - datatypes/index.md
+    - DateTime: datatypes/datetime.md

--- a/spec/datatypes/datetime.md
+++ b/spec/datatypes/datetime.md
@@ -1,0 +1,27 @@
+<!---
+SPDX-License-Identifier: Community-Spec-1.0
+SPDX-FileCopyrightText: 2022 Sebastian Crane <seabass-labrax@gmx.com>
+-->
+
+# DateTime
+
+`DateTime` is a signed integer of milliseconds since or before the Unix Epoch[^epoch].
+`DateTime` MUST be expressed as a series of base-10 digits, and MUST NOT be expressed with any leading zeroes, an exponent, a decimal point or a fractional part.
+
+## Examples
+
+### Valid
+
+| Canonical value | Semantic meaning                           |
+|:----------------|:-------------------------------------------|
+| `1657544400200` | 14:00:00.2 UTC on the 11th of July, 2022   |
+| `-127573208000` | 13:00:08 UTC on the 16th of December, 1965 |
+
+### Invalid
+
+| Invalid value       | Reason                           |
+|:--------------------|:---------------------------------|
+| `-000144960400000`  | Leading zeroes are not allowed   |
+| `1259607600000.141` | Fractional parts are not allowed |
+
+[^epoch]: See <https://en.wikipedia.org/wiki/Unix_time>

--- a/spec/datatypes/index.md
+++ b/spec/datatypes/index.md
@@ -1,0 +1,6 @@
+<!---
+SPDX-License-Identifier: Community-Spec-1.0
+SPDX-FileCopyrightText: 2022 Sebastian Crane <seabass-labrax@gmx.com>
+-->
+
+# Data Types


### PR DESCRIPTION
Adds the `DateTime` data type to the specification, as discussed during the [May 6th Canonicalisation Committee meeting](https://github.com/spdx/meetings/blob/main/canonical/2022-05-06.md).

Signed-off-by: Sebastian Crane <seabass-labrax@gmx.com>